### PR TITLE
Add Contributions Command

### DIFF
--- a/dbqueries.py
+++ b/dbqueries.py
@@ -31,13 +31,13 @@ def open_con(running_server=True):
         return False
 
 
-def query(_query, con):
+def query(_query, con, exec_args=None):
     back = True
     if con is None:
         phone_api.bot_crashed("Database Crash")
         return {}
     cur = con.cursor()
-    cur.execute(_query)
+    cur.execute(_query, exec_args)
     if _query[:6] == "SELECT":
         back = cur.fetchall()
         field_names = [i[0] for i in cur.description]


### PR DESCRIPTION
Hi!

I thought it would be cool to check which problems people have contributed to, and I think whether a user is a contributor to a problem can now be recognised to some extent (though not through the minimal api!) since they will no longer appear on the top solvers list.  In a bit more detail:

Get the time the user solved a problem from their recent solves history, is this less than the most recent solver in the top 100 and are they absent from the top solvers list?

The main function added is `is_contributor`:

```python3
is_contributor("heteroing", 821) # True 
is_contributor("__LW__", 821)    # False
is_contributor("heteroing", 822) # False
is_contributor("__LW__", 822)    # False
```
Which the new command basically delegates to.
This PR persists the contributions a user has made, I can only guess the schema from the sql snippets, but I think something along the lines of this should work:
```sql
CREATE TABLE IF NOT EXISTS problem_contributions (
  username VARCHAR(255) NOT NULL,
  problem INT NOT NULL,
  PRIMARY KEY (username, problem),
  FOREIGN KEY (username) REFERENCES members(username) ON DELETE CASCADE
);
```
I've been able to test `is_contributor`, but I don't really know enough about discord and it's API to test the levels above that, hopefully this is interesting nontheless.

Thanks :slightly_smiling_face: 